### PR TITLE
p-riak-cs v1.5.15 updates

### DIFF
--- a/index.html.md
+++ b/index.html.md
@@ -10,8 +10,8 @@ This is documentation for the [Riak CS service](https://network.pivotal.io/produ
 Current Riak CS for Pivotal Cloud Foundry Details
 <div style="line-height: 1; padding-left: 3em">
 
-- **Version**: 1.5.14
-- **Release Date**: 2016-08-24
+- **Version**: 1.5.15
+- **Release Date**: 2016-09-01
 - **Software component version**: Riak CS 1.5.4, Riak 1.4.12
 - **Compatible Ops Manager Version(s)**: 1.4.x, 1.5.x, 1.6.x, 1.7.x
 - **Compatible Elastic Runtime Version(s)**: 1.4.5, 1.5.x, 1.6.x, 1.7.x
@@ -59,12 +59,12 @@ For more information, refer to the full [Product Version Matrix](http://docs.piv
 <tr>
 	<th rowspan="2">1.4.x, 1.5.x, and 1.6.x</th>
 	<td>1.4.0</td>
-	<td>1.5.1 - 1.5.14</td>
+	<td>1.5.1 - 1.5.15</td>
 </tr>
 
 <tr>
-	<td>1.5.1 - 1.5.12</td>
-	<td>Next 1.5.x release - 1.5.14</td>
+	<td>1.5.1 - 1.5.14</td>
+	<td>Next 1.5.x release - 1.5.15</td>
 </tr>
 
 </table>

--- a/release-notes.html.md
+++ b/release-notes.html.md
@@ -3,11 +3,18 @@ title: Release Notes
 owner: Riak
 ---
 
+## <a id="1-5-15"></a>1.5.15
+
+Release date: 2 September 2016
+
+- **Bug fix:** Addresses a minor issue which prevents users from upgrading to OpsManager 1.8.
+  <p class="note"><strong>Note</strong>: If the Riak CS service is installed, you must upgrade to this version of Riak CS before upgrading to OpsManager 1.8.</p>
+
 ## <a id="1-5-14"></a>1.5.14
 
 Release date: 24 August 2016
 
-- **Bug:** Resolves an issue in which access logs are not automatically deleted.
+- **Bug fix:** Resolves an issue in which access logs are not automatically deleted.
   - In addition to being automatically rotated, logs are now compressed and deleted after seven days.
 - Updated stemcell to 3232.17. This is a security upgrade that resolves the following:
   - [USN-3064-1](http://www.ubuntu.com/usn/USN-3064-1/)


### PR DESCRIPTION
Accounts for v1.5.15 which includes the bug fix necessary to upgrade to OpsManager 1.8.
